### PR TITLE
Hotfix:  Remove auto commit hash updates from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build-dev-fast: ## Slower to compile, faster to execute. Builds all projects
 	@set -e; \
 	./choo hoon/main.hoon hoon; \
 	cp out.jam assets/jocktest.jam; \
-	python3 update-cargo.py; \
+	# python3 update-cargo.py; \
 	cargo build $(PROFILE_DEV_FAST)
 
 .PHONY: build-parallel
@@ -54,7 +54,7 @@ build-parallel: ## profiling profile with parallel feature enabled
 	@set -e; \
 	./choo hoon/main.hoon hoon; \
 	cp out.jam assets/jocktest.jam; \
-	python3 update-cargo.py; \
+	# python3 update-cargo.py; \
 	cargo build $(FEATURES_PARALLEL) $(PROFILE_PROFILING)
 
 .PHONY: build
@@ -62,7 +62,7 @@ build-dev-debug: ## Fast to compile, slow to execute. Builds all projects
 	@set -e; \
 	./choo hoon/main.hoon hoon; \
 	cp out.jam assets/jocktest.jam; \
-	python3 update-cargo.py; \
+	# python3 update-cargo.py; \
 	cargo build
 
 .PHONY: build-release
@@ -70,7 +70,7 @@ build-release: ## Slowest to compile, fastest to execute. Builds all projects
 	@set -e; \
 	./choo hoon/main.hoon hoon; \
 	cp out.jam assets/jocktest.jam; \
-	python3 update-cargo.py; \
+	# python3 update-cargo.py; \
 	cargo build $(PROFILE_RELEASE)
 
 .PHONY: update-choo


### PR DESCRIPTION
This capability proves to be convenient to have but not to always use.