### PR TITLE
Change from kebab case to snake case

### DIFF
--- a/common/hoon/lib/jock.hoon
+++ b/common/hoon/lib/jock.hoon
@@ -154,7 +154,10 @@
   ::  This only happens if there is a name or type immediately preceding '(',
   ::  e.g. foo(bar)  ->  'foo' '((' 'bar' ')'
   ++  tagged-name        (stag %name name)                :: [%name term]
-  ++  name               sym                              :: term
+  ++  name               snek                             :: term with _
+  ++  snek               %+  cook
+                           |=(a=tape (rap 3 ^-((list @) a)))
+                         ;~(plug low (star ;~(pose nud low cab)))
   ::
   ++  tagged-type        (stag %type type)                :: [%type 'Cord']
   ++  type               aul                              :: Cord

--- a/common/hoon/try/fibonacci.jock
+++ b/common/hoon/try/fibonacci.jock
@@ -1,12 +1,12 @@
 // fibonacci
 
-func fib(n:@) -> @ {
-  if n == 0 {
+func fib(n_:@) -> @ {
+  if n_ == 0 {
     1
-  } else if n == 1 {
+  } else if n_ == 1 {
     1
   } else {
-    $(n - 1) + $(n - 2)
+    $(n_ - 1) + $(n_ - 2)
   }
 };
 


### PR DESCRIPTION
Avoids `x-1` being a variable name instead of an expression.